### PR TITLE
[#27] boost 의존성 제거

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 - OS : Windows, Linux
 - Language : C++
 - Using Library
-  - Network : Boost.Asio
+  - Network : Asio standalone
   - Serialization : Protobuf
 - Used IDE : Visual Studio
 

--- a/logic-server/logic-server/ContextManager.cpp
+++ b/logic-server/logic-server/ContextManager.cpp
@@ -1,7 +1,7 @@
 #include "ContextManager.h"
 
 ContextManager::ContextManager(PrivateInternalTag, std::string contextName, const std::size_t blockingThreadCount)
-    : _contextName(contextName), _blockingPool(blockingThreadCount), _workGuard(boost::asio::make_work_guard(_ctx))
+    : _contextName(contextName), _blockingPool(blockingThreadCount), _workGuard(asio::make_work_guard(_ctx))
 {
 }
 

--- a/logic-server/logic-server/ContextManager.h
+++ b/logic-server/logic-server/ContextManager.h
@@ -4,10 +4,10 @@
 #include <vector>
 
 #include <spdlog/spdlog.h>
-#include <boost/asio.hpp>
-#include <boost/asio/thread_pool.hpp>
+#include <asio.hpp>
+#include <asio/thread_pool.hpp>
 
-using ThreadPool = boost::asio::thread_pool;
+using ThreadPool = asio::thread_pool;
 class ContextManager : public std::enable_shared_from_this<ContextManager>
 {
 private:
@@ -20,16 +20,16 @@ public:
     void Stop();
 
     // For Use io_context normally
-    boost::asio::io_context& GetContext() { return _ctx; }
+    asio::io_context& GetContext() { return _ctx; }
 
     // For Use BlockingPool (use this for heavy work)
     ThreadPool& GetBlockingPool() { return _blockingPool; }
 
 private:
-    boost::asio::io_context _ctx;
+    asio::io_context _ctx;
     ThreadPool _blockingPool;
 
-    boost::asio::executor_work_guard<boost::asio::io_context::executor_type> _workGuard;
+    asio::executor_work_guard<asio::io_context::executor_type> _workGuard;
     std::vector<std::shared_ptr<std::thread>> _ctxThreads;
 
     std::string _contextName;

--- a/logic-server/logic-server/GroupManager.h
+++ b/logic-server/logic-server/GroupManager.h
@@ -8,10 +8,8 @@
 #include <spdlog/spdlog.h>
 #include <spdlog/sinks/basic_file_sink.h>
 
-#include <boost/asio.hpp>
-#include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_io.hpp>
-#include <boost/uuid/string_generator.hpp>
+#include <asio.hpp>
+#include <stduuid/uuid.h>
 
 #include <google/protobuf/util/json_util.h>
 
@@ -22,7 +20,7 @@ class Session;
 class LockstepGroup;
 class ContextManager;
 
-using namespace boost::uuids;
+using uuids::uuid;
 using namespace NetworkData;
 
 class GroupManager : public std::enable_shared_from_this<GroupManager>
@@ -38,9 +36,8 @@ public:
 
 private:
     std::shared_ptr<ContextManager> _ctxManager;
-    boost::asio::io_context::strand _privateStrand;
-    boost::uuids::string_generator _toUuid; // string to uuid utility
-
+    asio::io_context::strand _privateStrand;
+    
     std::mutex _groupMutex;
     std::unordered_map<uuid, std::shared_ptr<LockstepGroup>> _groups;
 

--- a/logic-server/logic-server/LockstepGroup.h
+++ b/logic-server/logic-server/LockstepGroup.h
@@ -9,11 +9,8 @@
 #include <functional>
 #include <atomic>
 
-#include <boost/asio.hpp>
-#include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_io.hpp>
-#include <boost/uuid/uuid_hash.hpp>
-#include <boost/uuid/string_generator.hpp>
+#include <asio.hpp>
+#include <stduuid/uuid.h>
 
 #include <spdlog/spdlog.h>
 #include <spdlog/sinks/basic_file_sink.h>
@@ -22,8 +19,8 @@
 #include "PacketProcess.h"
 #include "NetworkData.pb.h"
 
-using IoContext = boost::asio::io_context;
-using namespace boost::uuids;
+using IoContext = asio::io_context;
+using uuids::uuid;
 using namespace NetworkData;
 
 using CompletionHandler = std::function<void()>;
@@ -60,7 +57,7 @@ public:
 	void CollectInput(std::shared_ptr<std::pair<uuid, std::shared_ptr<RpcPacket>>> rpcRequest);
 	void Tick(CompletionHandler onComplete);
 
-	uuid GetGroupId() const { return _toUuid(_groupInfo->groupid()); }
+	uuid GetGroupId() const { return *uuid::from_string(_groupInfo->groupid()); }
 
 	bool IsFull()
 	{
@@ -72,9 +69,8 @@ public:
 
 private:
 	std::shared_ptr<ContextManager> _ctxManager;
-    boost::asio::io_context::strand _privateStrand;
+    asio::io_context::strand _privateStrand;
 
-	boost::uuids::string_generator _toUuid;
 	std::shared_ptr<GroupDto> _groupInfo;
 
 	std::mutex _memberMutex;

--- a/logic-server/logic-server/PacketProcess.h
+++ b/logic-server/logic-server/PacketProcess.h
@@ -5,22 +5,21 @@
 
 #include <spdlog/spdlog.h>
 
-#include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_io.hpp>
+#include <stduuid/uuid.h>
 
 #include "NetworkData.pb.h"
 
-using namespace boost::uuids;
+using uuids::uuid;
 using namespace NetworkData;
 
 static void MakeHitPacket(uuid attacker, uuid victim, std::shared_ptr<RpcPacket>& out, std::int32_t dmg)
 {
     RpcPacket hitPacket;
-    hitPacket.set_uid(to_string(victim));
+    hitPacket.set_uid(uuids::to_string(victim));
     hitPacket.set_method(RpcMethod::Hit);
 
     HitData hitData;
-    hitData.set_attacker(to_string(attacker));
+    hitData.set_attacker(uuids::to_string(attacker));
     hitData.set_dmg(dmg);
 
     std::string serializedHitData;

--- a/logic-server/logic-server/Scheduler.cpp
+++ b/logic-server/logic-server/Scheduler.cpp
@@ -3,24 +3,24 @@
 Scheduler::Scheduler(IoContext::strand& strand, const std::chrono::milliseconds cycleTime, TaskHandler handler)
     : _strand(strand), _cycleTime(cycleTime), _handler(std::move(handler))
 {
-    _timer = std::make_shared<boost::asio::steady_timer>(strand.context());
+    _timer = std::make_shared<asio::steady_timer>(strand.context());
 }
 
 void Scheduler::Start()
 {
     auto self(shared_from_this());
-    boost::asio::post(_strand, [self] { self->DoStart(); });
+    asio::post(_strand, [self] { self->DoStart(); });
 }
 
 void Scheduler::DoStart()
 {
     auto self(shared_from_this());
     _timer->expires_after(_cycleTime);
-    _timer->async_wait([self](const boost::system::error_code& ec)
+    _timer->async_wait([self](const std::error_code& ec)
     {
         if (ec)
         {
-            if (ec == boost::asio::error::operation_aborted)
+            if (ec == asio::error::operation_aborted)
             {
                 spdlog::info("scheduler aborted");
                 return; // Timer was stopped
@@ -37,5 +37,5 @@ void Scheduler::DoStart()
 void Scheduler::Stop(bool forceStop)
 {
     auto self(shared_from_this());
-    boost::asio::post(_strand, [self] { self->_timer->cancel(); });
+    asio::post(_strand, [self] { self->_timer->cancel(); });
 }

--- a/logic-server/logic-server/Scheduler.h
+++ b/logic-server/logic-server/Scheduler.h
@@ -1,6 +1,6 @@
 #pragma once
-#include <boost/asio.hpp>
-#include <boost/asio/steady_timer.hpp>
+#include <asio.hpp>
+#include <asio/steady_timer.hpp>
 #include <memory>
 #include <functional>
 #include <chrono>
@@ -14,7 +14,7 @@ using TaskHandler = std::function<void(CompletionHandler)>;
 class Scheduler : public Base<Scheduler>
 {
 public:
-    using IoContext = boost::asio::io_context;
+    using IoContext = asio::io_context;
 
     Scheduler(IoContext::strand& strand, const std::chrono::milliseconds cycleTime, TaskHandler handler);
     void Start() override;
@@ -23,7 +23,7 @@ public:
 
 private:
     IoContext::strand& _strand;
-    std::shared_ptr<boost::asio::steady_timer> _timer;
+    std::shared_ptr<asio::steady_timer> _timer;
     std::chrono::milliseconds _cycleTime;
     TaskHandler _handler;
 

--- a/logic-server/logic-server/Server.h
+++ b/logic-server/logic-server/Server.h
@@ -1,8 +1,6 @@
 #pragma once
-#include <boost/asio.hpp>
-#include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_io.hpp>
-#include <boost/uuid/random_generator.hpp>
+#include <asio.hpp>
+#include <stduuid/uuid.h>
 #include <spdlog/spdlog.h>
 #include <spdlog/sinks/basic_file_sink.h>
 
@@ -19,10 +17,10 @@
 #include "NetworkData.pb.h"
 #include "ContextManager.h"
 
-using IoContext = boost::asio::io_context;
-using namespace boost::asio::ip;
+using IoContext = asio::io_context;
+using namespace asio::ip;
 using namespace NetworkData;
-
+using uuids::uuid;
 
 class Session;
 class LockstepGroup;
@@ -42,10 +40,9 @@ private:
 	std::shared_ptr<ContextManager> _normalCtxManager;
 	std::shared_ptr<ContextManager> _rpcCtxManager;
 	tcp::acceptor& _acceptor;
-    boost::uuids::string_generator _toUuid;
 
-	boost::asio::io_context::strand _normalPrivateStrand;
-	boost::asio::io_context::strand _rpcPrivateStrand;
+	asio::io_context::strand _normalPrivateStrand;
+	asio::io_context::strand _rpcPrivateStrand;
 
     std::shared_ptr<UdpSocket> _udpSocket;
     std::uint16_t _allocatedUdpPort;

--- a/logic-server/logic-server/Session.h
+++ b/logic-server/logic-server/Session.h
@@ -1,13 +1,11 @@
 #pragma once
 
-#include <boost/asio.hpp>
-#include <boost/uuid/uuid.hpp>
+#include <asio.hpp>
+#include <stduuid/uuid.h>
 #include <spdlog/spdlog.h>
 #include <spdlog/sinks/basic_file_sink.h>
 
 #include <memory>
-#include <boost/uuid/uuid_io.hpp>
-#include <boost/uuid/string_generator.hpp>
 #include <queue>
 
 #include "Base.h"
@@ -17,11 +15,11 @@
 
 using namespace NetworkData;
 
-using IoContext = boost::asio::io_context;
-using error_code = boost::system::error_code;
-using boost::asio::ip::tcp;
-using boost::asio::ip::udp;
-using boost::uuids::uuid;
+using IoContext = asio::io_context;
+using error_code = std::error_code;
+using asio::ip::tcp;
+using asio::ip::udp;
+using uuids::uuid;
 
 class Server;
 class LockstepGroup;
@@ -69,7 +67,7 @@ private: // internal private functions
 
 public: // default session functions
     bool IsValid() const { return _isConnected; }
-    uuid GetSessionUuid() const { return _toUuid(_sessionInfo.uid()); }
+    uuid GetSessionUuid() const { return *uuid::from_string(_sessionInfo.uid()); }
 
     void CollectInput(std::shared_ptr<RpcPacket> receivePacket);
     void EnqueueSendUdpPackets(const std::list<std::shared_ptr<SSendPacket>> sendPackets);
@@ -93,16 +91,13 @@ private: // default members
     using TcpSocket = tcp::socket;
     using UdpSocket = udp::socket;
 
-    // uuid parser
-    boost::uuids::string_generator _toUuid;
-
-    // boost asio context
+    // asio context
     std::shared_ptr<ContextManager> _normalCtxManager;
     std::shared_ptr<ContextManager> _rpcCtxManager;
-    boost::asio::io_context::strand _normalPrivateStrand;
-    boost::asio::io_context::strand _rpcPrivateStrand;
+    asio::io_context::strand _normalPrivateStrand;
+    asio::io_context::strand _rpcPrivateStrand;
 
-    // boost asio sockets
+    // asio sockets
     std::shared_ptr<TcpSocket> _tcpSocketPtr;
     std::shared_ptr<UdpSocket> _udpSocketPtr;
     udp::endpoint _udpSendEp;

--- a/logic-server/logic-server/Util.h
+++ b/logic-server/logic-server/Util.h
@@ -2,8 +2,7 @@
 #include <string>
 #include <chrono>
 
-#include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_io.hpp>
+#include <stduuid/uuid.h>
 
 #include "NetworkData.pb.h"
 using namespace NetworkData;
@@ -56,7 +55,7 @@ namespace Util
 
 	struct UserSimpleDto
 	{
-		boost::uuids::uuid userId;
+		uuids::uuid userId;
 		std::string name;
 	};
 

--- a/logic-server/logic-server/logic-server.vcxproj
+++ b/logic-server/logic-server/logic-server.vcxproj
@@ -102,7 +102,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;ASIO_STANDALONE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalOptions>/utf-8 
@@ -120,7 +120,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;ASIO_STANDALONE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>

--- a/logic-server/logic-server/main.cpp
+++ b/logic-server/logic-server/main.cpp
@@ -1,4 +1,4 @@
-#include <boost/asio.hpp>
+#include <asio.hpp>
 #include <memory>
 #include <thread>
 #include <vector>
@@ -12,7 +12,7 @@
 
 constexpr bool NO_WEB_SERVER_MODE = true;
 constexpr unsigned short SERVER_PORT = 53200;
-using namespace boost::asio::ip;
+using namespace asio::ip;
 
 int main()
 {
@@ -70,7 +70,7 @@ int main()
     ConsoleMonitor::Get().Stop();
     spdlog::set_default_logger(spdlog::stdout_color_mt("console"));
 
-    server->Stop(1);
+    server->Stop(true);
 
     workThreadContext->Stop();
     rpcThreadContext->Stop();


### PR DESCRIPTION
- boost에 의존하던 모든 라이브러리에 대해 의존성을 제거하는 작업을 완료함

### 주요 변경
- <boost/asio.hpp> 에서 <asio.hpp>로 헤더가 변경됨
- <boost/uuid.hpp>에서 <stduuid/uuid.h>로 헤더가 변경됨
- boost에 의존하던 error_code를 std::error_code로 변경함

resolved #27 